### PR TITLE
Fix resource version update upon resync

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.13, 1.14]
+        goversion: [1.13, 1.14, 1.15]
     steps:
 
     - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}

--- a/k8s_pod_watcher.go
+++ b/k8s_pod_watcher.go
@@ -273,11 +273,13 @@ func (p *PodWatcher) Run(ctx context.Context) error {
 	resync := func() resyncAction {
 		newversion, resyncErr := p.resync(ctx, cbChans)
 		if resyncErr != nil {
+			p.logf("resync failed: %s", resyncErr)
 			if sleepBackoff() {
 				return resyncReturn
 			}
 			return resyncContinueLoop
 		}
+		p.logf("resync succeeded; new version: %q (old %q)", newversion, version)
 		version = newversion
 		return resyncSuccess
 	}

--- a/k8s_pod_watcher.go
+++ b/k8s_pod_watcher.go
@@ -302,6 +302,7 @@ func (p *PodWatcher) Run(ctx context.Context) error {
 		rv, err := p.watch(ctx, podWatch, version, cbChans)
 		switch err {
 		case ErrResultsClosed:
+			version = rv
 		case errVersionGone:
 			switch resync() {
 			case resyncReturn:
@@ -313,7 +314,6 @@ func (p *PodWatcher) Run(ctx context.Context) error {
 		default:
 			return err
 		}
-		version = rv
 
 		// If it's been a while, reset the backoff so we don't wait too
 		// long after things have been humming for an hour.

--- a/k8s_pod_watcher_test.go
+++ b/k8s_pod_watcher_test.go
@@ -17,6 +17,7 @@ package k8swatcher
 import (
 	"context"
 	"net"
+	"net/http"
 	"reflect"
 	"sync"
 	"testing"
@@ -614,7 +615,7 @@ func (goneErr) Error() string {
 }
 
 func (goneErr) Status() k8smeta.Status {
-	return k8smeta.Status{Reason: k8smeta.StatusReasonGone}
+	return k8smeta.Status{Reason: k8smeta.StatusReasonGone, Code: http.StatusGone}
 }
 
 type dummyPods struct {


### PR DESCRIPTION
By assigning to `version` after the switch statement, any new version
set within `resync` gets clobbered by the one that wa returned by watch,
which is by definition stale if we decided to resync.


Reproducing the infinite loop with minikube, (k8s version v1.18.3) the
status I get back after restarting minikube was different than in GKE
with k8s version 1.16. (likely to differences in the reproduction setup)
The Reason field was "Expired" rather than "Gone", but the Code field
was still 410 (`net/http.StatusGone`). Switch to checking that code
instead.

Add some additional logging to make it clear when a resync happened.