### PR TITLE
Minor linter cleanups

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -1,0 +1,14 @@
+name: "StaticCheck"
+on: ["push", "pull_request"]
+
+jobs:
+  ci:
+    name: "staticcheck"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: dominikh/staticcheck-action@v1.1.0
+      with:
+        version: "2021.1.1"

--- a/k8s_pod_watcher.go
+++ b/k8s_pod_watcher.go
@@ -47,7 +47,7 @@ func InitKubernetesInClusterClient() (kubernetes.Interface, error) {
 	// creates a kubernetes clientset with the config initialized above
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return clientset, fmt.Errorf("Error initializing kubernetes client. Error: %s", err)
+		return clientset, fmt.Errorf("error initializing kubernetes client. Error: %s", err)
 	}
 	return clientset, nil
 }
@@ -473,7 +473,7 @@ func (p *PodWatcher) watch(ctx context.Context, podWatch watch.Interface, rv str
 				continue
 			}
 			lastRV = pod.ResourceVersion
-			podName := pod.ObjectMeta.Name
+			podName := pod.Name
 			podIP := pod.Status.PodIP
 			ipaddr := net.ParseIP(podIP)
 			var clientEvent PodEvent


### PR DESCRIPTION
in order of fixes:
ST1005 -- https://staticcheck.io/docs/checks/#ST1005
  - fix an error string to start with a lowercase letter
QF1008 -- https://staticcheck.io/docs/checks/#QF1008
  - access pod.Name rather than pod.ObjectMeta.Name

note: `QF1008` is not easily accessible from the cmdline `staticcheck` tool, but shows up when `gopls` runs its analyzers/fixers (`QF` is short for "Quick Fix").

Also, add a staticcheck github action to lock in the gains.